### PR TITLE
Feat: Allow HEMCO to export additional fields to pbuf

### DIFF
--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -726,6 +726,23 @@ contains
                 if(masterproc) write(iulog,*) "Exported exportName " // trim(exportName) // " to history"
             enddo
 
+            ! UVALBEDO
+            write(exportnametmp, '(a)') 'uvalbedo'
+            exportName = 'HCO_' // trim(exportNameTmp)
+            exportDesc = "HEMCO Chemistry Input Name " // trim(exportNameTmp)
+
+            ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
+            ! Too lazy to write an Export_CAM2D
+            call addfld(exportName, (/'lev'/), 'I', 'nM',               &
+                        trim(exportDesc),                               &
+                        gridname='physgrid')
+            ! call add_default(exportName, 2, 'I') ! On by default
+
+            ! Also pbuf
+            call HCO_Export_Pbuf_AddField(exportNameTmp, 3)
+
+            if(masterproc) write(iulog,*) "Exported exportName " // trim(exportName) // " to history"
+
             ! SURF_IODIDE
             write(exportnametmp, '(a)') 'iodide'
             exportName = 'HCO_' // trim(exportNameTmp)
@@ -1418,6 +1435,33 @@ contains
                 call HCO_Export_History_CAM3D(exportName, exportFldCAM)
                 call HCO_Export_Pbuf_CAM3D(exportNameTmp, -1, exportFldCAM)
             enddo
+
+            ! UVALBEDO
+            write(exportNameTmp, '(a)') 'uvalbedo'
+            exportName = 'HCO_' // trim(exportNameTmp)
+
+            ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
+            ! Too lazy to write an Export_CAM2D
+            exportFldHco(:,:,:) = 0.0_r8
+            exportFldCAM(:,:)   = 0.0_r8
+
+            do J = my_JS, my_JE
+                HJ = J - my_JS + 1
+            do I = my_IS, my_IE
+                HI = I - my_IS + 1
+
+                ! Grab the pointer if available
+                call HCO_GetPtr(HcoState, exportNameTmp, Ptr2D, HMRC)
+                if(HMRC == HCO_SUCCESS) exportFldHco(:,:,1) = Ptr2D ! Copy data in
+            enddo
+            enddo
+
+            write(exportNameTmp, '(a)') 'uvalbedo'
+            exportName = 'HCO_' // trim(exportNameTmp)
+
+            call HCO_Grid_HCO2CAM_3D(exportFldHco, exportFldCAM)
+            call HCO_Export_History_CAM3D(exportName, exportFldCAM)
+            call HCO_Export_Pbuf_CAM3D(exportNameTmp, -1, exportFldCAM)
 
             ! SURF_SALINITY
             write(exportNameTmp, '(a)') 'surf_salinity'

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -722,9 +722,43 @@ contains
 
                 ! Also pbuf
                 call HCO_Export_Pbuf_AddField(exportNameTmp, 3)
-                
+
                 if(masterproc) write(iulog,*) "Exported exportName " // trim(exportName) // " to history"
             enddo
+
+            ! SURF_IODIDE
+            write(exportnametmp, '(a)') 'iodide'
+            exportName = 'HCO_' // trim(exportNameTmp)
+            exportDesc = "HEMCO Chemistry Input Name " // trim(exportNameTmp)
+
+            ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
+            ! Too lazy to write an Export_CAM2D
+            call addfld(exportName, (/'lev'/), 'I', 'nM',               &
+                        trim(exportDesc),                               &
+                        gridname='physgrid')
+            ! call add_default(exportName, 2, 'I') ! On by default
+
+            ! Also pbuf
+            call HCO_Export_Pbuf_AddField(exportNameTmp, 3)
+
+            if(masterproc) write(iulog,*) "Exported exportName " // trim(exportName) // " to history"
+
+            ! SURF_SALINITY
+            write(exportnametmp, '(a)') 'salinity'
+            exportName = 'HCO_' // trim(exportNameTmp)
+            exportDesc = "HEMCO Chemistry Input Name " // trim(exportNameTmp)
+
+            ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
+            ! Too lazy to write an Export_CAM2D
+            call addfld(exportName, (/'lev'/), 'I', 'PSU',              &
+                        trim(exportDesc),                               &
+                        gridname='physgrid')
+            ! call add_default(exportName, 2, 'I') ! On by default
+
+            ! Also pbuf
+            call HCO_Export_Pbuf_AddField(exportNameTmp, 3)
+
+            if(masterproc) write(iulog,*) "Exported exportName " // trim(exportName) // " to history"
 
             if(masterproc) then
                 write(iulog,*) "> HEMCO additional exports for CESM2-GC initialized!"
@@ -1384,6 +1418,65 @@ contains
                 call HCO_Export_History_CAM3D(exportName, exportFldCAM)
                 call HCO_Export_Pbuf_CAM3D(exportNameTmp, -1, exportFldCAM)
             enddo
+
+            ! SURF_SALINITY
+            write(exportNameTmp, '(a)') 'surf_salinity'
+            exportName = 'HCO_' // trim(exportNameTmp)
+
+            ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
+            ! Too lazy to write an Export_CAM2D
+            exportFldHco(:,:,:) = 0.0_r8
+            exportFldCAM(:,:)   = 0.0_r8
+
+            do J = my_JS, my_JE
+                HJ = J - my_JS + 1
+            do I = my_IS, my_IE
+                HI = I - my_IS + 1
+
+                ! Grab the pointer if available
+                call HCO_GetPtr(HcoState, exportNameTmp, Ptr2D, HMRC)
+                if(HMRC == HCO_SUCCESS) exportFldHco(:,:,1) = Ptr2D ! Copy data in
+            enddo
+            enddo
+
+            ! This is required as the physics buffer cannot store
+            ! `HCO_surf_salinity` as it is too long.. We thus export as
+            ! `HCO_salinity`
+            write(exportNameTmp, '(a)') 'salinity'
+            exportName = 'HCO_' // trim(exportNameTmp)
+
+            call HCO_Grid_HCO2CAM_3D(exportFldHco, exportFldCAM)
+            call HCO_Export_History_CAM3D(exportName, exportFldCAM)
+            call HCO_Export_Pbuf_CAM3D(exportNameTmp, -1, exportFldCAM)
+
+            ! SURF_IODIDE
+            write(exportNameTmp, '(a)') 'surf_iodide'
+            exportName = 'HCO_' // trim(exportNameTmp)
+
+            ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
+            ! Too lazy to write an Export_CAM2D
+            exportFldHco(:,:,:) = 0.0_r8
+            exportFldCAM(:,:)   = 0.0_r8
+
+            do J = my_JS, my_JE
+                HJ = J - my_JS + 1
+            do I = my_IS, my_IE
+                HI = I - my_IS + 1
+
+                ! Grab the pointer if available
+                call HCO_GetPtr(HcoState, exportNameTmp, Ptr2D, HMRC)
+                if(HMRC == HCO_SUCCESS) exportFldHco(:,:,1) = Ptr2D ! Copy data in
+            enddo
+            enddo
+
+            ! See above comment about `HCO_surf_salinity`
+            write(exportNameTmp, '(a)') 'iodide'
+            exportName = 'HCO_' // trim(exportNameTmp)
+
+            call HCO_Grid_HCO2CAM_3D(exportFldHco, exportFldCAM)
+            call HCO_Export_History_CAM3D(exportName, exportFldCAM)
+            call HCO_Export_Pbuf_CAM3D(exportNameTmp, -1, exportFldCAM)
+
         endif
 
         dummy_0_CAM(:,:) = iam * 1.0_r8

--- a/hemco_interface.F90
+++ b/hemco_interface.F90
@@ -727,13 +727,13 @@ contains
             enddo
 
             ! UVALBEDO
-            write(exportnametmp, '(a)') 'uvalbedo'
+            write(exportnameTmp, '(a)') 'UV_ALBEDO'
             exportName = 'HCO_' // trim(exportNameTmp)
             exportDesc = "HEMCO Chemistry Input Name " // trim(exportNameTmp)
 
             ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
             ! Too lazy to write an Export_CAM2D
-            call addfld(exportName, (/'lev'/), 'I', 'nM',               &
+            call addfld(exportName, (/'lev'/), 'I', '1',                &
                         trim(exportDesc),                               &
                         gridname='physgrid')
             ! call add_default(exportName, 2, 'I') ! On by default
@@ -744,7 +744,7 @@ contains
             if(masterproc) write(iulog,*) "Exported exportName " // trim(exportName) // " to history"
 
             ! SURF_IODIDE
-            write(exportnametmp, '(a)') 'iodide'
+            write(exportnameTmp, '(a)') 'iodide'
             exportName = 'HCO_' // trim(exportNameTmp)
             exportDesc = "HEMCO Chemistry Input Name " // trim(exportNameTmp)
 
@@ -761,7 +761,7 @@ contains
             if(masterproc) write(iulog,*) "Exported exportName " // trim(exportName) // " to history"
 
             ! SURF_SALINITY
-            write(exportnametmp, '(a)') 'salinity'
+            write(exportnameTmp, '(a)') 'salinity'
             exportName = 'HCO_' // trim(exportNameTmp)
             exportDesc = "HEMCO Chemistry Input Name " // trim(exportNameTmp)
 
@@ -1437,7 +1437,7 @@ contains
             enddo
 
             ! UVALBEDO
-            write(exportNameTmp, '(a)') 'uvalbedo'
+            write(exportNameTmp, '(a)') 'UV_ALBEDO'
             exportName = 'HCO_' // trim(exportNameTmp)
 
             ! FIXME (hplin): Exporting as 3-D; third dimension unused, change later...
@@ -1455,9 +1455,6 @@ contains
                 if(HMRC == HCO_SUCCESS) exportFldHco(:,:,1) = Ptr2D ! Copy data in
             enddo
             enddo
-
-            write(exportNameTmp, '(a)') 'uvalbedo'
-            exportName = 'HCO_' // trim(exportNameTmp)
 
             call HCO_Grid_HCO2CAM_3D(exportFldHco, exportFldCAM)
             call HCO_Export_History_CAM3D(exportName, exportFldCAM)


### PR DESCRIPTION
(1) The physics buffer does not allow to store strings as long as
    `HCO_surf_salinity` and would, for instance, store
    `HCO_surf_salinit`. To avoid confusion, we rename it to
    `HCO_salinity`, same for `HCO_iodide`.

Signed-off-by: Thibaud Fritz <fritzt@mit.edu>