### PR TITLE
Add .exclude file containing HEMCO files to skip during build

### DIFF
--- a/.exclude
+++ b/.exclude
@@ -1,0 +1,2 @@
+HEMCO/src/Core/hcoio_read_mapl_mod.F90
+HEMCO/src/Core/hcoio_write_mapl_mod.F90


### PR DESCRIPTION
This update enables skipping two HEMCO files that cause the build to crash if present. It should be used with CIME updates submitted in: https://github.com/ESMCI/cime/pull/4180 and https://github.com/ESMCI/cime/pull/4302.